### PR TITLE
feature: added lifecycle scripts

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,7 +4,7 @@
 *.dll
 *.so
 *.dylib
-microgateway
+bin/
 
 # Test binary, built with `go test -c`
 *.test

--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@
 *.dll
 *.so
 *.dylib
-microgateway
+bin/
 
 # Test binary, built with `go test -c`
 *.test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,18 @@
+stages:
+  - release
+jobs:
+  include:
+    - stage: release
+      if: tag IS present
+      before_install:
+        - curl -fsSL https://get.docker.com | sh
+        - echo '{"experimental":"enabled"}' | sudo tee /etc/docker/daemon.json
+        - mkdir -p $HOME/.docker
+        - echo '{"experimental":"enabled"}' | sudo tee $HOME/.docker/config.json
+        - sudo service docker start
+      install:
+        - docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+      script: make release
+      skip_cleanup: true
+      on:
+        tags: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,11 @@
-FROM golang:1.13
+FROM golang:1.14.2
 
 ENV WORKDIR /go/src/microgateway
 RUN mkdir ${WORKDIR}
 WORKDIR ${WORKDIR}
-ADD . . ${WORKDIR}/
+ADD .. ${WORKDIR}/
 
 RUN curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
-RUN dep ensure -v
-RUN go install -v .
+RUN make install
 
 CMD ["microgateway"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,18 @@
+.PHONY: clean deps format build run
+all: build
+clean:
+	rm -rf bin/
+deps:
+	dep ensure -v
+format:
+	go fmt .
+build: clean deps format
+	go build -o bin/microgateway -v .
+install: deps format
+	go install -v .
+run: build
+	./bin/microgateway
+release:
+	./scripts/release.sh
+deploy:
+	./scripts/deploy.sh

--- a/README.md
+++ b/README.md
@@ -1,19 +1,17 @@
 # microgateway
+[![Build Status](https://travis-ci.org/gosmo-devs/microgateway.svg?branch=develop)](https://travis-ci.org/gosmo-devs/microgateway)
 
 A simple, lightweight and blazingly fast Microgateway written in Go
 
 ## Development
 
-Install [golang/dep](https://github.com/golang/dep) for dependency management and then run:
-
 ```
-$ dep ensure
-$ go run .
+$ make run
 ```
 
 ## Production
 
 ```
-$ docker build -t microgateway .
-$ docker run -it --name microgateway -p 8080:8080 -d microgateway
+$ make release
+$ make deploy
 ```

--- a/main.go
+++ b/main.go
@@ -1,5 +1,5 @@
 package main
 
 func main() {
-	APIInit()
+	NewAPI()
 }

--- a/manifests/00_namespace.yml
+++ b/manifests/00_namespace.yml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: microgateway
+  labels:
+    app: microgateway

--- a/manifests/01_microgateway_configmap.yml
+++ b/manifests/01_microgateway_configmap.yml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: microgateway
+  namespace: microgateway
+  labels:
+    app: microgateway
+    tier: api-gateway
+data:
+  PORT: :80

--- a/manifests/microgateway.yml
+++ b/manifests/microgateway.yml
@@ -1,0 +1,67 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: microgateway
+  namespace: microgateway
+  labels:
+    app: microgateway
+    tier: api-gateway
+spec:
+  selector:
+    app: microgateway
+    tier: api-gateway
+  type: NodePort
+  ports:
+    - port: 80
+      nodePort: 30080
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: microgateway
+  namespace: microgateway
+  labels:
+    app: microgateway
+    tier: api-gateway
+spec:
+  selector:
+    matchLabels:
+      app: microgateway
+      tier: api-gateway
+  template:
+    metadata:
+      labels:
+        app: microgateway
+        tier: api-gateway
+    spec:
+      containers:
+        - name: microgateway
+          image: gosmogolang/microgateway:0.0.1
+          imagePullPolicy: Always
+          resources:
+            requests:
+              memory: "64Mi"
+              cpu: "250m"
+            limits:
+              memory: "128Mi"
+              cpu: "500m"
+          ports:
+            - name: service-port
+              containerPort: 80
+          readinessProbe:
+            httpGet:
+              path: /api/health
+              port: service-port
+            initialDelaySeconds: 10
+            timeoutSeconds: 3
+            periodSeconds: 15
+          livenessProbe:
+            httpGet:
+              path: /api/health
+              port: service-port
+            initialDelaySeconds: 10
+            timeoutSeconds: 3
+            periodSeconds: 15
+          envFrom:
+            - configMapRef:
+                name: microgateway

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+set -e
+
+kubectl apply -f manifests

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+set -e
+
+docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
+
+tag=$(git describe --abbrev=0 --tags)
+project="microgateway"
+image="gosmogolang/$project:$tag"
+platform="linux/amd64,linux/arm64"
+
+echo "👷   Creating builder $project ..."
+docker buildx create --name "$project"
+docker buildx use "$project"
+
+echo "🏗    Building $image ..."
+docker buildx build --platform "$platform" -t "$image" --push .
+docker buildx imagetools inspect "$image"


### PR DESCRIPTION
This PR needs to be reviewed first before proceding with the current one:
https://github.com/gosmo-devs/microgateway/pull/6

Requirements for testing this PR:
- [golang/dep](https://golang.github.io/dep/docs/installation.html)
- [minikube](https://kubernetes.io/es/docs/tasks/tools/install-minikube)

Features added in this PR:
- Lifecycle scripts via Makefile
- `release.sh`: Builds Docker images for multiple architectures and pushes them to [DockerHub](https://hub.docker.com/repository/docker/gosmogolang/microgateway/general)
- [TravisCI](https://travis-ci.org/github/gosmo-devs/microgateway/builds): Executes `release.sh` when a tag is pushed
- `deploy.sh`: Deploys microgateway to a Kubernetes cluster

Closes #7 